### PR TITLE
Unifying the Free and Finally Tagless representations

### DIFF
--- a/ThreatDragonModels/some review/some review.json
+++ b/ThreatDragonModels/some review/some review.json
@@ -1,0 +1,17 @@
+{
+  "summary": {
+    "owner": "you",
+    "title": "some review"
+  },
+  "detail": {
+    "contributors": [],
+    "diagrams": [
+      {
+        "title": "rrrr",
+        "thumbnail": "./public/content/images/thumbnail.jpg",
+        "id": 0
+      }
+    ],
+    "reviewer": "me"
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -13,8 +13,11 @@ scalacOptions in ThisBuild ++= Seq(
   "-language:higherKinds"
 )
 
+addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.3")
+
 libraryDependencies ++= Seq(
-  "org.typelevel" %% "cats" % "0.9.0",
+  "org.typelevel" %% "cats-core" % "0.9.0",
+  "org.typelevel" %% "cats-free" % "0.9.0",
   "org.scalactic" %% "scalactic" % "3.0.1",
   "org.scalatest" %% "scalatest" % "3.0.1" % "test"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,16 @@ name := "FreeMonads"
 
 version := "1.0"
 
-scalaVersion := "2.12.1"
+scalaVersion := "2.12.3"
 
-scalacOptions in ThisBuild ++= Seq("-unchecked", "-deprecation")
+scalacOptions in ThisBuild ++= Seq(
+  "-deprecation",
+  "-unchecked",
+  "-feature",
+  "-Xlint",
+  "-Xfatal-warnings",
+  "-language:higherKinds"
+)
 
 libraryDependencies ++= Seq(
   "org.typelevel" %% "cats" % "0.9.0",

--- a/project/coursier.sbt
+++ b/project/coursier.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("io.get-coursier"   % "sbt-coursier"  % "1.0.0-RC2")

--- a/src/main/scala/free/CountriesAlg.scala
+++ b/src/main/scala/free/CountriesAlg.scala
@@ -1,0 +1,9 @@
+package free
+
+import model.{Country, CountryDetail}
+
+sealed trait CountriesAlg[A]
+
+case class GetCountries() extends CountriesAlg[List[Country]]
+case class GetCountyDetail(country: Country) extends CountriesAlg[Option[CountryDetail]]
+

--- a/src/main/scala/free/CountriesAlg.scala
+++ b/src/main/scala/free/CountriesAlg.scala
@@ -4,6 +4,6 @@ import model.{Country, CountryDetail}
 
 sealed trait CountriesAlg[A]
 
-case class GetCountries() extends CountriesAlg[List[Country]]
-case class GetCountyDetail(country: Country) extends CountriesAlg[Option[CountryDetail]]
+case class Countries() extends CountriesAlg[List[Country]]
+case class CountyDetail(country: Country) extends CountriesAlg[Option[CountryDetail]]
 

--- a/src/main/scala/free/CountriesApiAlg.scala
+++ b/src/main/scala/free/CountriesApiAlg.scala
@@ -1,9 +1,9 @@
 package free
 
-import model.{Country, CountryDetail, LogLevel}
+import model.{Country, CountryDetail}
 
 sealed trait CountriesApiAlg[A]
 
 case class GetCountries() extends CountriesApiAlg[List[Country]]
-case class GetCountyDetail(country: Country) extends CountriesApiAlg[CountryDetail]
+case class GetCountyDetail(country: Country) extends CountriesApiAlg[Option[CountryDetail]]
 

--- a/src/main/scala/free/CountriesApiAlg.scala
+++ b/src/main/scala/free/CountriesApiAlg.scala
@@ -1,9 +1,0 @@
-package free
-
-import model.{Country, CountryDetail}
-
-sealed trait CountriesApiAlg[A]
-
-case class GetCountries() extends CountriesApiAlg[List[Country]]
-case class GetCountyDetail(country: Country) extends CountriesApiAlg[Option[CountryDetail]]
-

--- a/src/main/scala/free/CountriesService.scala
+++ b/src/main/scala/free/CountriesService.scala
@@ -16,9 +16,9 @@ object CountriesService {
     for {
       _         <- info("Starting")
       _         <- info("Getting Countries")
-      countries <- getCountries
+      countries <- countries
       _         <- info("Getting Details")
-      cd        <- countries.traverseU(getCountryDetail)
+      cd        <- countries.traverseU(countryDetail)
       _         <- info("Completed")
     } yield countries.zip(cd)
   }

--- a/src/main/scala/free/CountriesService.scala
+++ b/src/main/scala/free/CountriesService.scala
@@ -8,7 +8,7 @@ object CountriesService {
   import DSL._
 
   def fetchCountries(implicit C: CountryOps[Algebra], L: LoggerOps[Algebra]):
-   Service[List[(Country, CountryDetail)]] = {
+   Service[List[(Country, Option[CountryDetail])]] = {
 
     import C._
     import L._

--- a/src/main/scala/free/CountryOpsInterpreters.scala
+++ b/src/main/scala/free/CountryOpsInterpreters.scala
@@ -25,7 +25,7 @@ object CountryOpsInterpreters {
     new (CountriesApiAlg ~> F) {
       override def apply[A](fa: CountriesApiAlg[A]): F[A] = fa match {
         case GetCountyDetail(country) =>
-          t.getCountyDetail(country).map(_.asInstanceOf[A])
+          t.getCountryDetail(country).map(_.asInstanceOf[A])
 
         case GetCountries() =>
           t.getCountries.map(_.asInstanceOf[A])

--- a/src/main/scala/free/CountryOpsInterpreters.scala
+++ b/src/main/scala/free/CountryOpsInterpreters.scala
@@ -1,26 +1,19 @@
 package free
 
 import cats.instances.future._
-
 import cats.syntax.functor._
 import cats.{Functor, ~>}
-import model.{Country, CountryDetail}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 object CountryOpsInterpreters {
 
-  val countries = Seq(
-    Country("England", "London", "Europe", "flag"),
-    Country("Spain", "Madrid", "Europe", "flag")
-  )
-
-  val countryDetail = Seq(
-    CountryDetail("England", "GBP"),
-    CountryDetail("Spain", "Euro")
-  )
-
+  /**
+    * Build a interpreter of the Free algebra out of an implementation of the tagless API
+    * by simply extracting the parameters from each case class and delegating to the
+    * api implementation.
+    */
   def fCountryInterpreter[F[_]](t: tagless.CountriesApi[F])(implicit fFunctor: Functor[F]) =
     new (CountriesAlg ~> F) {
       override def apply[A](fa: CountriesAlg[A]): F[A] = fa match {

--- a/src/main/scala/free/CountryOpsInterpreters.scala
+++ b/src/main/scala/free/CountryOpsInterpreters.scala
@@ -1,10 +1,7 @@
 package free
 
-import cats.instances.future._
-import cats.syntax.functor._
-import cats.{Functor, ~>}
+import cats.~>
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 object CountryOpsInterpreters {
@@ -14,14 +11,12 @@ object CountryOpsInterpreters {
     * by simply extracting the parameters from each case class and delegating to the
     * api implementation.
     */
-  def fCountryInterpreter[F[_]](t: tagless.CountriesApi[F])(implicit fFunctor: Functor[F]) =
+  def fCountryInterpreter[F[_]](t: tagless.CountriesApi[F]) =
     new (CountriesAlg ~> F) {
       override def apply[A](fa: CountriesAlg[A]): F[A] = fa match {
-        case GetCountyDetail(country) =>
-          t.getCountryDetail(country).map(_.asInstanceOf[A])
+        case GetCountyDetail(country) => t.getCountryDetail(country)
 
-        case GetCountries() =>
-          t.getCountries.map(_.asInstanceOf[A])
+        case GetCountries() => t.getCountries
       }
     }
 

--- a/src/main/scala/free/CountryOpsInterpreters.scala
+++ b/src/main/scala/free/CountryOpsInterpreters.scala
@@ -34,24 +34,6 @@ object CountryOpsInterpreters {
 
   val listStateCountryInterpreter = fCountryInterpreter[ListState](tagless.StateCountriesApiInterpreter)
 
-//    new (CountriesApiAlg ~> ListState) {
-//    override def apply[A](op: CountriesApiAlg[A]): ListState[A] = op match {
-//      case GetCountyDetail(country) => {
-//        val result = countryDetail.find(_.name.equalsIgnoreCase(country.name))
-//        addToState(
-//          s"Got details: \n\t${result.map(c => s"${country.name} -> ${c.currency}").mkString("\n")}",
-//          result.asInstanceOf[A]
-//        )
-//      }
-//
-//      case GetCountries() =>
-//        addToState(
-//          s"Got countries: \n\t${countries.map(c => s"${c.name} with capital ${c.capital}").mkString("\n")}",
-//          countries.toList.asInstanceOf[A]
-//        )
-//    }
-//  }
-
   val futureCountryInterpreter = fCountryInterpreter[Future](tagless.CountriesApiInterpreter)
 
 }

--- a/src/main/scala/free/CountryOpsInterpreters.scala
+++ b/src/main/scala/free/CountryOpsInterpreters.scala
@@ -21,9 +21,9 @@ object CountryOpsInterpreters {
     CountryDetail("Spain", "Euro")
   )
 
-  def fCountryInterpreter[F[_]](t: tagless.CountriesApiAlg[F])(implicit fFunctor: Functor[F]) =
-    new (CountriesApiAlg ~> F) {
-      override def apply[A](fa: CountriesApiAlg[A]): F[A] = fa match {
+  def fCountryInterpreter[F[_]](t: tagless.CountriesApi[F])(implicit fFunctor: Functor[F]) =
+    new (CountriesAlg ~> F) {
+      override def apply[A](fa: CountriesAlg[A]): F[A] = fa match {
         case GetCountyDetail(country) =>
           t.getCountryDetail(country).map(_.asInstanceOf[A])
 
@@ -32,8 +32,8 @@ object CountryOpsInterpreters {
       }
     }
 
-  val listStateCountryInterpreter = fCountryInterpreter[ListState](tagless.StateCountriesApiInterpreter)
+  val listStateCountryInterpreter = fCountryInterpreter[ListState](tagless.CountriesStateInterpreter)
 
-  val futureCountryInterpreter = fCountryInterpreter[Future](tagless.CountriesApiInterpreter)
+  val futureCountryInterpreter = fCountryInterpreter[Future](tagless.CountriesFutureInterpreter)
 
 }

--- a/src/main/scala/free/CountryOpsInterpreters.scala
+++ b/src/main/scala/free/CountryOpsInterpreters.scala
@@ -14,9 +14,9 @@ object CountryOpsInterpreters {
   def fCountryInterpreter[F[_]](t: tagless.CountriesApi[F]) =
     new (CountriesAlg ~> F) {
       override def apply[A](fa: CountriesAlg[A]): F[A] = fa match {
-        case GetCountyDetail(country) => t.getCountryDetail(country)
+        case CountyDetail(country) => t.countryDetail(country)
 
-        case GetCountries() => t.getCountries
+        case Countries() => t.countries
       }
     }
 

--- a/src/main/scala/free/DSL.scala
+++ b/src/main/scala/free/DSL.scala
@@ -1,8 +1,8 @@
 package free
 
 import cats.free.{Free, Inject}
-import model._
 import model.LogLevel._
+import model._
 
 /**
   * The dsl will lift the algebra into a free monad by use of smart constructors
@@ -14,7 +14,8 @@ object DSL {
     * CountryOps provides a set of functions replicating the types that are found
     * in the algebra. These functions help instantiate the algebraic data types.
     */
-  class CountryOps[F[_]](implicit I: Inject[CountriesApiAlg, F]) {
+  class CountryOps[F[_]](implicit I: Inject[CountriesApiAlg, F])
+    extends tagless.CountriesApiAlg[Free[F, ?]] {
 
     def getCountries: Free[F, List[Country]] =
       Free.inject[CountriesApiAlg, F](GetCountries())
@@ -24,24 +25,18 @@ object DSL {
 
   }
 
-  class LoggerOps[F[_]](implicit L: Inject[LoggerAlg, F]) {
+  class LoggerOps[F[_]](implicit L: Inject[LoggerAlg, F])
+    extends tagless.LoggerApiAlg[Free[F, ?]] {
 
-    def debug(msg: String): Free[F, Unit] =
-      Free.inject[LoggerAlg, F](LogMsg(DebugLevel, msg))
-
-    def warn(msg: String): Free[F, Unit] =
-      Free.inject[LoggerAlg, F](LogMsg(WarnLevel, msg))
-
-    def info(msg: String): Free[F, Unit] =
-      Free.inject[LoggerAlg, F](LogMsg(InfoLevel, msg))
-
-    def error(msg: String): Free[F, Unit] =
+    override def logMsg(level: LogLevel, msg: String): Free[F, Unit] =
       Free.inject[LoggerAlg, F](LogMsg(ErrorLevel, msg))
+
   }
 
   object CountryOps {
     implicit def countryOps[F[_]](
-      implicit I: Inject[CountriesApiAlg, F]): CountryOps[F] =
+      implicit I: Inject[CountriesApiAlg, F]
+    ): CountryOps[F] =
       new CountryOps[F]
   }
 

--- a/src/main/scala/free/DSL.scala
+++ b/src/main/scala/free/DSL.scala
@@ -13,15 +13,13 @@ object DSL {
   /**
     * CountryOps provides a set of functions replicating the types that are found
     * in the algebra. These functions help instantiate the algebraic data types.
-    * @param I
-    * @tparam F
     */
   class CountryOps[F[_]](implicit I: Inject[CountriesApiAlg, F]) {
 
     def getCountries: Free[F, List[Country]] =
       Free.inject[CountriesApiAlg, F](GetCountries())
 
-    def getCountryDetail(country: Country): Free[F, CountryDetail] =
+    def getCountryDetail(country: Country): Free[F, Option[CountryDetail]] =
       Free.inject[CountriesApiAlg, F](GetCountyDetail(country))
 
   }

--- a/src/main/scala/free/DSL.scala
+++ b/src/main/scala/free/DSL.scala
@@ -13,6 +13,18 @@ object DSL {
   /**
     * CountryOps provides a set of functions replicating the types that are found
     * in the algebra. These functions help instantiate the algebraic data types.
+    *
+    * Note that the methods on CountryOps are the same as the methods on the finally tagless
+    * CountriesApi trait. This means CountryOps can be an implementation of the tagless
+    * api. So an application that is using tagless can use this class as an interpreter to
+    * convert a program to the Free algebra.
+    *
+    * Compare that to `CountryOpsInterpreters.fCountryInterpreter`, which can interpret
+    * the Free case-class algebra using an implementation of the tagless api. I.e.
+    * `fCountryInterpreter` is a general way of building a Free interpreter out of
+    * a tagless implementation.
+    *
+    * The combination of these two all trivial conversion between Free and Finally Tagless.
     */
   class CountryOps[F[_]](implicit I: Inject[CountriesAlg, F])
     extends tagless.CountriesApi[Free[F, ?]] {
@@ -22,7 +34,6 @@ object DSL {
 
     def getCountryDetail(country: Country): Free[F, Option[CountryDetail]] =
       Free.inject[CountriesAlg, F](GetCountyDetail(country))
-
   }
 
   class LoggerOps[F[_]](implicit L: Inject[LoggerAlg, F])
@@ -30,7 +41,6 @@ object DSL {
 
     override def logMsg(level: LogLevel, msg: String): Free[F, Unit] =
       Free.inject[LoggerAlg, F](LogMsg(ErrorLevel, msg))
-
   }
 
   object CountryOps {

--- a/src/main/scala/free/DSL.scala
+++ b/src/main/scala/free/DSL.scala
@@ -14,19 +14,19 @@ object DSL {
     * CountryOps provides a set of functions replicating the types that are found
     * in the algebra. These functions help instantiate the algebraic data types.
     */
-  class CountryOps[F[_]](implicit I: Inject[CountriesApiAlg, F])
-    extends tagless.CountriesApiAlg[Free[F, ?]] {
+  class CountryOps[F[_]](implicit I: Inject[CountriesAlg, F])
+    extends tagless.CountriesApi[Free[F, ?]] {
 
     def getCountries: Free[F, List[Country]] =
-      Free.inject[CountriesApiAlg, F](GetCountries())
+      Free.inject[CountriesAlg, F](GetCountries())
 
     def getCountryDetail(country: Country): Free[F, Option[CountryDetail]] =
-      Free.inject[CountriesApiAlg, F](GetCountyDetail(country))
+      Free.inject[CountriesAlg, F](GetCountyDetail(country))
 
   }
 
   class LoggerOps[F[_]](implicit L: Inject[LoggerAlg, F])
-    extends tagless.LoggerApiAlg[Free[F, ?]] {
+    extends tagless.LoggerApi[Free[F, ?]] {
 
     override def logMsg(level: LogLevel, msg: String): Free[F, Unit] =
       Free.inject[LoggerAlg, F](LogMsg(ErrorLevel, msg))
@@ -35,7 +35,7 @@ object DSL {
 
   object CountryOps {
     implicit def countryOps[F[_]](
-      implicit I: Inject[CountriesApiAlg, F]
+      implicit I: Inject[CountriesAlg, F]
     ): CountryOps[F] =
       new CountryOps[F]
   }

--- a/src/main/scala/free/DSL.scala
+++ b/src/main/scala/free/DSL.scala
@@ -29,11 +29,11 @@ object DSL {
   class CountryOps[F[_]](implicit I: Inject[CountriesAlg, F])
     extends tagless.CountriesApi[Free[F, ?]] {
 
-    def getCountries: Free[F, List[Country]] =
-      Free.inject[CountriesAlg, F](GetCountries())
+    def countries: Free[F, List[Country]] =
+      Free.inject[CountriesAlg, F](Countries())
 
-    def getCountryDetail(country: Country): Free[F, Option[CountryDetail]] =
-      Free.inject[CountriesAlg, F](GetCountyDetail(country))
+    def countryDetail(country: Country): Free[F, Option[CountryDetail]] =
+      Free.inject[CountriesAlg, F](CountyDetail(country))
   }
 
   class LoggerOps[F[_]](implicit L: Inject[LoggerAlg, F])

--- a/src/main/scala/free/FreeCountryApplication.scala
+++ b/src/main/scala/free/FreeCountryApplication.scala
@@ -29,7 +29,6 @@ object FreeCountryApplication extends App with ApplicationWrapper {
       fetchCountries
         .foldMap(interpreters)
 
-
     val result = program.runEmpty.value
   }
 

--- a/src/main/scala/free/FreeCountryApplication.scala
+++ b/src/main/scala/free/FreeCountryApplication.scala
@@ -1,15 +1,17 @@
 package free
 
-import model.{Country, CountryDetail}
 import cats.implicits._
+import model.{Country, CountryData, CountryDetail}
 import utils.ApplicationWrapper
 
-import scala.concurrent.{Await, Future}
 import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
 
 object FreeCountryApplication extends App with ApplicationWrapper {
-  import scala.concurrent.ExecutionContext.Implicits.global
+
   import CountriesService._
+
+  import scala.concurrent.ExecutionContext.Implicits.global
 
   /**
     * Bringing together the program (provided by CountriesService) and
@@ -47,26 +49,16 @@ object FreeCountryApplication extends App with ApplicationWrapper {
 
   application("Free") {
     appVariantExecution("State Monad") {
-      StateBasedApplication.result._2.foreach { lc =>
-        printf("%-5s %-10s %-10s %-10s %-10s\n",
-               "",
-               lc._1.name,
-               lc._1.capital,
-               lc._1.region,
-               lc._2.map(_.currency))
+      StateBasedApplication.result._2.foreach {
+        case (c, d) => CountryData.printResult(c, d)
       }
-    }
-    appVariantExecution("Future") {
-      val fResult = Await
-        .result(FutureBasedApplication.program, atMost = Duration.Inf)
+      appVariantExecution("Future") {
+        val fResult = Await
+          .result(FutureBasedApplication.program, atMost = Duration.Inf)
 
-      fResult.foreach { lc =>
-        printf("%-5s %-10s %-10s %-10s %-10s\n",
-               "",
-               lc._1.name,
-               lc._1.capital,
-               lc._1.region,
-               lc._2.map(_.currency))
+        fResult.foreach {
+          case (c, d) => CountryData.printResult(c, d)
+        }
       }
     }
 

--- a/src/main/scala/free/LoggerOpsInterpreters.scala
+++ b/src/main/scala/free/LoggerOpsInterpreters.scala
@@ -1,21 +1,16 @@
 package free
 
-import cats.instances.future._
-import cats.syntax.functor._
-import cats.{Functor, ~>}
-
-import scala.concurrent.ExecutionContext.Implicits.global
+import cats.~>
 
 object LoggerOpsInterpreters {
   /**
     * Implement an interpreter for the Free algebra of the Logger using
     * an instance of the tagless api
     */
-  def fLoggerInterpreter[F[_]](t: tagless.LoggerApi[F])(implicit fFunctor: Functor[F]) =
+  def fLoggerInterpreter[F[_]](t: tagless.LoggerApi[F]) =
     new (LoggerAlg ~> F) {
       override def apply[A](fa: LoggerAlg[A]): F[A] = fa match {
-        case LogMsg(level, msg) =>
-          t.logMsg(level, msg).map(_.asInstanceOf[A])
+        case LogMsg(level, msg) => t.logMsg(level, msg)
       }
     }
 

--- a/src/main/scala/free/LoggerOpsInterpreters.scala
+++ b/src/main/scala/free/LoggerOpsInterpreters.scala
@@ -1,10 +1,8 @@
 package free
 
 import cats.~>
-import cats.data.OptionT
-import cats.instances.future._
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 object LoggerOpsInterpreters {
   val loggerListStateInterpreter = new (LoggerAlg ~> ListState) {
@@ -12,9 +10,9 @@ object LoggerOpsInterpreters {
       addToState(chooseMessage(a), ().asInstanceOf[A])
   }
 
-  val futureOfOptionInterpreter = new (LoggerAlg ~> FutureOfOption) {
-    override def apply[A](fa: LoggerAlg[A]): FutureOfOption[A] =
-      OptionT.pure(().asInstanceOf[A])
+  val futureInterpreter = new (LoggerAlg ~> Future) {
+    override def apply[A](fa: LoggerAlg[A]): Future[A] =
+      Future.successful(().asInstanceOf[A])
   }
 
   def chooseMessage[A](a: LoggerAlg[A]): String = a match {

--- a/src/main/scala/free/package.scala
+++ b/src/main/scala/free/package.scala
@@ -1,10 +1,7 @@
-import cats.data.{Coproduct, OptionT, State}
+import cats.data.{Coproduct, State}
 import cats.free.Free
 
-import scala.concurrent.Future
-
 package object free {
-  type FutureOfOption[A] = OptionT[Future, A]
   type Algebra[A]        = Coproduct[CountriesAlg, LoggerAlg, A]
   type Service[A]        = Free[Algebra, A]
   type ListState[A]      = State[List[String], A]

--- a/src/main/scala/free/package.scala
+++ b/src/main/scala/free/package.scala
@@ -5,7 +5,7 @@ import scala.concurrent.Future
 
 package object free {
   type FutureOfOption[A] = OptionT[Future, A]
-  type Algebra[A]        = Coproduct[CountriesApiAlg, LoggerAlg, A]
+  type Algebra[A]        = Coproduct[CountriesAlg, LoggerAlg, A]
   type Service[A]        = Free[Algebra, A]
   type ListState[A]      = State[List[String], A]
 

--- a/src/main/scala/model/CountriesData.scala
+++ b/src/main/scala/model/CountriesData.scala
@@ -1,0 +1,17 @@
+package model
+
+object CountriesData {
+  private val england = "England"
+  private val spain = "Spain"
+  private val europe = "Europe"
+
+  val countries = List(
+    Country(england, "London", europe, "flag"),
+    Country(spain, "Madrid", europe, "flag")
+  )
+
+  val countryDetail = List(
+    CountryDetail(england, "GBP"),
+    CountryDetail(spain, "Euro")
+  )
+}

--- a/src/main/scala/model/CountryData.scala
+++ b/src/main/scala/model/CountryData.scala
@@ -5,13 +5,23 @@ object CountryData {
   private val spain = "Spain"
   private val europe = "Europe"
 
-  val countries = List(
+  val countryData = List(
     Country(england, "London", europe, "flag"),
     Country(spain, "Madrid", europe, "flag")
   )
 
-  val countryDetail = List(
+  val countryDetailData = List(
     CountryDetail(england, "GBP"),
     CountryDetail(spain, "Euro")
   )
+
+  def printResult(c: Country, d: Option[CountryDetail]): Unit = {
+    printf(
+      "%-5s %-10s %-10s %-10s %-10s\n",
+      "",
+      c.name,
+      c.capital,
+      c.region,
+      d.map(_.currency))
+  }
 }

--- a/src/main/scala/model/CountryData.scala
+++ b/src/main/scala/model/CountryData.scala
@@ -1,6 +1,6 @@
 package model
 
-object CountriesData {
+object CountryData {
   private val england = "England"
   private val spain = "Spain"
   private val europe = "Europe"

--- a/src/main/scala/tagless/APIs.scala
+++ b/src/main/scala/tagless/APIs.scala
@@ -2,13 +2,13 @@ package tagless
 import model.LogLevel.{DebugLevel, ErrorLevel, InfoLevel, WarnLevel}
 import model.{Country, CountryDetail, LogLevel}
 
-trait CountriesApiAlg[F[_]] {
+trait CountriesApi[F[_]] {
   def getCountries: F[List[Country]]
 
   def getCountryDetail(country: Country): F[Option[CountryDetail]]
 }
 
-trait LoggerApiAlg[F[_]] {
+trait LoggerApi[F[_]] {
 
    def debug(msg: String): F[Unit] = logMsg(DebugLevel, msg)
 

--- a/src/main/scala/tagless/APIs.scala
+++ b/src/main/scala/tagless/APIs.scala
@@ -3,9 +3,9 @@ import model.LogLevel.{DebugLevel, ErrorLevel, InfoLevel, WarnLevel}
 import model.{Country, CountryDetail, LogLevel}
 
 trait CountriesApi[F[_]] {
-  def getCountries: F[List[Country]]
+  def countries: F[List[Country]]
 
-  def getCountryDetail(country: Country): F[Option[CountryDetail]]
+  def countryDetail(country: Country): F[Option[CountryDetail]]
 }
 
 trait LoggerApi[F[_]] {

--- a/src/main/scala/tagless/Algebras.scala
+++ b/src/main/scala/tagless/Algebras.scala
@@ -4,7 +4,7 @@ import model.{Country, CountryDetail, LogLevel}
 trait CountriesApiAlg[F[_]] {
   def getCountries: F[List[Country]]
 
-  def getCountyDetail(country: Country): F[CountryDetail]
+  def getCountyDetail(country: Country): F[Option[CountryDetail]]
 }
 
 trait Logger[F[_]] {

--- a/src/main/scala/tagless/Algebras.scala
+++ b/src/main/scala/tagless/Algebras.scala
@@ -1,12 +1,22 @@
 package tagless
+import model.LogLevel.{DebugLevel, ErrorLevel, InfoLevel, WarnLevel}
 import model.{Country, CountryDetail, LogLevel}
 
 trait CountriesApiAlg[F[_]] {
   def getCountries: F[List[Country]]
 
-  def getCountyDetail(country: Country): F[Option[CountryDetail]]
+  def getCountryDetail(country: Country): F[Option[CountryDetail]]
 }
 
-trait Logger[F[_]] {
-  def logMsg(level: LogLevel, msg: String): F[Unit]
+trait LoggerApiAlg[F[_]] {
+
+   def debug(msg: String): F[Unit] = logMsg(DebugLevel, msg)
+
+   def warn(msg: String): F[Unit] = logMsg(WarnLevel, msg)
+
+   def info(msg: String): F[Unit] = logMsg(InfoLevel, msg)
+
+   def error(msg: String): F[Unit] = logMsg(ErrorLevel, msg)
+
+   def logMsg(level: LogLevel, msg: String): F[Unit]
 }

--- a/src/main/scala/tagless/CountriesApiInterpreter.scala
+++ b/src/main/scala/tagless/CountriesApiInterpreter.scala
@@ -19,7 +19,7 @@ object CountriesApiInterpreter extends CountriesApiAlg[Future] {
   override def getCountries: Future[List[Country]] =
     Future.successful(countries.toList)
 
-  override def getCountyDetail(
+  override def getCountryDetail(
       country: Country): Future[Option[CountryDetail]] =
     Future.successful(countryDetail.find(_.name.equalsIgnoreCase(country.name)))
 }
@@ -41,7 +41,7 @@ object StateCountriesApiInterpreter extends CountriesApiAlg[ListState] {
     addToState(result.mkString(","), result)
   }
 
-  override def getCountyDetail(country: Country): ListState[Option[CountryDetail]] = {
+  override def getCountryDetail(country: Country): ListState[Option[CountryDetail]] = {
     val result = countryDetail.find(_.name.equalsIgnoreCase(country.name))
     addToState(result.toString, result)
   }

--- a/src/main/scala/tagless/CountriesApiInterpreter.scala
+++ b/src/main/scala/tagless/CountriesApiInterpreter.scala
@@ -1,12 +1,10 @@
 package tagless
 
 import model.{Country, CountryDetail}
-import cats.data.OptionT
-import cats.instances.future._
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
-object CountriesApiInterpreter extends CountriesApiAlg[FutureOfOption] {
+object CountriesApiInterpreter extends CountriesApiAlg[Future] {
 
   val countries = Seq(
     Country("England", "London", "Europe", "flag"),
@@ -18,12 +16,12 @@ object CountriesApiInterpreter extends CountriesApiAlg[FutureOfOption] {
     CountryDetail("Spain", "Euro")
   )
 
-  override def getCountries: FutureOfOption[List[Country]] =
-    OptionT.pure(countries.toList)
+  override def getCountries: Future[List[Country]] =
+    Future.successful(countries.toList)
 
   override def getCountyDetail(
-      country: Country): FutureOfOption[CountryDetail] =
-    OptionT.pure(countryDetail.find(_.name.equalsIgnoreCase(country.name)).get)
+      country: Country): Future[Option[CountryDetail]] =
+    Future.successful(countryDetail.find(_.name.equalsIgnoreCase(country.name)))
 }
 
 object StateCountriesApiInterpreter extends CountriesApiAlg[ListState] {
@@ -43,8 +41,8 @@ object StateCountriesApiInterpreter extends CountriesApiAlg[ListState] {
     addToState(result.mkString(","), result)
   }
 
-  override def getCountyDetail(country: Country): ListState[CountryDetail] = {
-    val result = countryDetail.find(_.name.equalsIgnoreCase(country.name)).get
+  override def getCountyDetail(country: Country): ListState[Option[CountryDetail]] = {
+    val result = countryDetail.find(_.name.equalsIgnoreCase(country.name))
     addToState(result.toString, result)
   }
 }

--- a/src/main/scala/tagless/CountriesInterpreters.scala
+++ b/src/main/scala/tagless/CountriesInterpreters.scala
@@ -1,28 +1,26 @@
 package tagless
 
-import model.{Country, CountryDetail}
+import model.{CountryData, Country, CountryDetail}
 
 import scala.concurrent.Future
 
 object CountriesFutureInterpreter extends CountriesApi[Future] {
-  import model.CountriesData._
 
-  override def getCountries: Future[List[Country]] =
-    Future.successful(countries)
+  override def countries: Future[List[Country]] =
+    Future.successful(CountryData.countries)
 
-  override def getCountryDetail(country: Country): Future[Option[CountryDetail]] =
-    Future.successful(countryDetail.find(_.name.equalsIgnoreCase(country.name)))
+  override def countryDetail(country: Country): Future[Option[CountryDetail]] =
+    Future.successful(CountryData.countryDetail.find(_.name.equalsIgnoreCase(country.name)))
 }
 
 object CountriesStateInterpreter extends CountriesApi[ListState] {
-  import model.CountriesData._
 
-  override def getCountries: ListState[List[Country]] = {
-    addToState(countries.mkString(","), countries)
+  override def countries: ListState[List[Country]] = {
+    addToState(CountryData.countries.mkString(","), CountryData.countries)
   }
 
-  override def getCountryDetail(country: Country): ListState[Option[CountryDetail]] = {
-    val result = countryDetail.find(_.name.equalsIgnoreCase(country.name))
+  override def countryDetail(country: Country): ListState[Option[CountryDetail]] = {
+    val result = CountryData.countryDetail.find(_.name.equalsIgnoreCase(country.name))
     addToState(result.toString, result)
   }
 }

--- a/src/main/scala/tagless/CountriesInterpreters.scala
+++ b/src/main/scala/tagless/CountriesInterpreters.scala
@@ -4,34 +4,21 @@ import model.{Country, CountryDetail}
 
 import scala.concurrent.Future
 
-object CountriesData {
-  val countries = Seq(
-    Country("England", "London", "Europe", "flag"),
-    Country("Spain", "Madrid", "Europe", "flag")
-  )
-
-  val countryDetail = Seq(
-    CountryDetail("England", "GBP"),
-    CountryDetail("Spain", "Euro")
-  )
-}
-
 object CountriesFutureInterpreter extends CountriesApi[Future] {
-  import CountriesData._
+  import model.CountriesData._
 
   override def getCountries: Future[List[Country]] =
-    Future.successful(countries.toList)
+    Future.successful(countries)
 
   override def getCountryDetail(country: Country): Future[Option[CountryDetail]] =
     Future.successful(countryDetail.find(_.name.equalsIgnoreCase(country.name)))
 }
 
 object CountriesStateInterpreter extends CountriesApi[ListState] {
-  import CountriesData._
+  import model.CountriesData._
 
   override def getCountries: ListState[List[Country]] = {
-    val result = countries.toList
-    addToState(result.mkString(","), result)
+    addToState(countries.mkString(","), countries)
   }
 
   override def getCountryDetail(country: Country): ListState[Option[CountryDetail]] = {

--- a/src/main/scala/tagless/CountriesInterpreters.scala
+++ b/src/main/scala/tagless/CountriesInterpreters.scala
@@ -4,8 +4,7 @@ import model.{Country, CountryDetail}
 
 import scala.concurrent.Future
 
-object CountriesApiInterpreter extends CountriesApiAlg[Future] {
-
+object CountriesData {
   val countries = Seq(
     Country("England", "London", "Europe", "flag"),
     Country("Spain", "Madrid", "Europe", "flag")
@@ -15,26 +14,20 @@ object CountriesApiInterpreter extends CountriesApiAlg[Future] {
     CountryDetail("England", "GBP"),
     CountryDetail("Spain", "Euro")
   )
+}
+
+object CountriesFutureInterpreter extends CountriesApi[Future] {
+  import CountriesData._
 
   override def getCountries: Future[List[Country]] =
     Future.successful(countries.toList)
 
-  override def getCountryDetail(
-      country: Country): Future[Option[CountryDetail]] =
+  override def getCountryDetail(country: Country): Future[Option[CountryDetail]] =
     Future.successful(countryDetail.find(_.name.equalsIgnoreCase(country.name)))
 }
 
-object StateCountriesApiInterpreter extends CountriesApiAlg[ListState] {
-
-  val countries = Seq(
-    Country("England", "London", "Europe", "flag"),
-    Country("Spain", "Madrid", "Europe", "flag")
-  )
-
-  val countryDetail = Seq(
-    CountryDetail("England", "GBP"),
-    CountryDetail("Spain", "Euro")
-  )
+object CountriesStateInterpreter extends CountriesApi[ListState] {
+  import CountriesData._
 
   override def getCountries: ListState[List[Country]] = {
     val result = countries.toList

--- a/src/main/scala/tagless/CountriesInterpreters.scala
+++ b/src/main/scala/tagless/CountriesInterpreters.scala
@@ -5,22 +5,24 @@ import model.{CountryData, Country, CountryDetail}
 import scala.concurrent.Future
 
 object CountriesFutureInterpreter extends CountriesApi[Future] {
+  import CountryData._
 
   override def countries: Future[List[Country]] =
-    Future.successful(CountryData.countries)
+    Future.successful(countryData)
 
   override def countryDetail(country: Country): Future[Option[CountryDetail]] =
-    Future.successful(CountryData.countryDetail.find(_.name.equalsIgnoreCase(country.name)))
+    Future.successful(countryDetailData.find(_.name.equalsIgnoreCase(country.name)))
 }
 
 object CountriesStateInterpreter extends CountriesApi[ListState] {
+  import CountryData._
 
   override def countries: ListState[List[Country]] = {
-    addToState(CountryData.countries.mkString(","), CountryData.countries)
+    addToState(countryData.mkString(","), countryData)
   }
 
   override def countryDetail(country: Country): ListState[Option[CountryDetail]] = {
-    val result = CountryData.countryDetail.find(_.name.equalsIgnoreCase(country.name))
+    val result = countryDetailData.find(_.name.equalsIgnoreCase(country.name))
     addToState(result.toString, result)
   }
 }

--- a/src/main/scala/tagless/CountriesService.scala
+++ b/src/main/scala/tagless/CountriesService.scala
@@ -15,9 +15,9 @@ class CountriesService[F[_]: Monad](countriesApi: CountriesApi[F], logger: Logge
     for {
       _  <- info("Starting")
       _  <- info("Getting Countries")
-      cs <- getCountries
+      cs <- countries
       _  <- info("Getting Details")
-      cd <- cs.traverse(getCountryDetail)
+      cd <- cs.traverse(countryDetail)
       _  <- info("Completed")
     } yield cs.zip(cd)
 }

--- a/src/main/scala/tagless/CountriesService.scala
+++ b/src/main/scala/tagless/CountriesService.scala
@@ -6,7 +6,7 @@ import model.{Country, CountryDetail}
 
 import scala.language.higherKinds
 
-class CountriesService[F[_]: Monad](countriesApi: CountriesApiAlg[F], logger: LoggerApiAlg[F]) {
+class CountriesService[F[_]: Monad](countriesApi: CountriesApi[F], logger: LoggerApi[F]) {
 
   import countriesApi._
   import logger._

--- a/src/main/scala/tagless/CountriesService.scala
+++ b/src/main/scala/tagless/CountriesService.scala
@@ -11,7 +11,7 @@ class CountriesService[F[_]: Monad](countriesApi: CountriesApiAlg[F], logger: Lo
 
   import logger._, countriesApi._
 
-  def getCountriesWithDetails: F[List[(Country, CountryDetail)]] =
+  def getCountriesWithDetails: F[List[(Country, Option[CountryDetail])]] =
     for {
       _  <- logMsg(InfoLevel, "Starting")
       _  <- logMsg(InfoLevel, "Getting Countries")

--- a/src/main/scala/tagless/CountriesService.scala
+++ b/src/main/scala/tagless/CountriesService.scala
@@ -1,23 +1,23 @@
 package tagless
 
 import cats.Monad
-import model.{Country, CountryDetail}
 import cats.implicits._
-import model.LogLevel._
+import model.{Country, CountryDetail}
 
 import scala.language.higherKinds
 
-class CountriesService[F[_]: Monad](countriesApi: CountriesApiAlg[F], logger: Logger[F]) {
+class CountriesService[F[_]: Monad](countriesApi: CountriesApiAlg[F], logger: LoggerApiAlg[F]) {
 
-  import logger._, countriesApi._
+  import countriesApi._
+  import logger._
 
   def getCountriesWithDetails: F[List[(Country, Option[CountryDetail])]] =
     for {
-      _  <- logMsg(InfoLevel, "Starting")
-      _  <- logMsg(InfoLevel, "Getting Countries")
+      _  <- info("Starting")
+      _  <- info("Getting Countries")
       cs <- getCountries
-      _  <- logMsg(InfoLevel, "Getting Details")
-      cd <- cs.traverse(getCountyDetail)
-      _  <- logMsg(InfoLevel, "Completed")
+      _  <- info("Getting Details")
+      cd <- cs.traverse(getCountryDetail)
+      _  <- info("Completed")
     } yield cs.zip(cd)
 }

--- a/src/main/scala/tagless/FinallyCountryApplication.scala
+++ b/src/main/scala/tagless/FinallyCountryApplication.scala
@@ -8,7 +8,8 @@ import scala.concurrent.{Await, Future}
 import scala.concurrent.duration.Duration
 
 object FinallyCountryApplication extends App with ApplicationWrapper {
-  import scala.concurrent.ExecutionContext.Implicits.global
+
+  implicit val ec = scala.concurrent.ExecutionContext.Implicits.global
 
   /**
     * Bringing together the CountriesService (representing the program) and
@@ -19,8 +20,8 @@ object FinallyCountryApplication extends App with ApplicationWrapper {
     */
   object StateBasedApplication {
     val countriesService =
-      new CountriesService(StateCountriesApiInterpreter,
-                           StateLoggerInterpreter)
+      new CountriesService(CountriesStateInterpreter,
+                           LoggerStateInterpreter)
 
     val result: (List[String], List[(Country, Option[CountryDetail])]) =
       countriesService.getCountriesWithDetails.runEmpty.value
@@ -28,13 +29,13 @@ object FinallyCountryApplication extends App with ApplicationWrapper {
   }
 
   /**
-    * Bringing together the ContriesService (represetnating the program) and
+    * Bringing together the CountriesService (representing the program) and
     * Future of Option interpreters that will provide implementations for the
     * program.
     */
   object FutureBasedApplication {
     val countriesService =
-      new CountriesService(CountriesApiInterpreter, FutureLoggerInterpreter)
+      new CountriesService(CountriesFutureInterpreter, LoggerFutureInterpreter)
 
     val result: Future[List[(Country, Option[CountryDetail])]] =
       countriesService.getCountriesWithDetails

--- a/src/main/scala/tagless/FinallyCountryApplication.scala
+++ b/src/main/scala/tagless/FinallyCountryApplication.scala
@@ -1,7 +1,7 @@
 package tagless
 
 import cats.implicits._
-import model.{Country, CountryDetail}
+import model.{Country, CountryData, CountryDetail}
 import utils.ApplicationWrapper
 
 import scala.concurrent.duration.Duration
@@ -45,7 +45,7 @@ object FinallyCountryApplication extends App with ApplicationWrapper {
   application("Tagless Final") {
     appVariantExecution("State Monad") {
       StateBasedApplication.result._2.foreach {
-        case (c, d) => printResult(c, d)
+        case (c, d) => CountryData.printResult(c, d)
       }
     }
 
@@ -53,7 +53,7 @@ object FinallyCountryApplication extends App with ApplicationWrapper {
       val futureResult = Await
         .result(FutureBasedApplication.result, atMost = Duration.Inf)
       futureResult.foreach {
-        case (c, d) => printResult(c, d)
+        case (c, d) => CountryData.printResult(c, d)
       }
     }
 
@@ -61,13 +61,5 @@ object FinallyCountryApplication extends App with ApplicationWrapper {
       StateBasedApplication.result._1.foreach(l => println(s"""\t$l""")))
   }
 
-  private def printResult(c: Country, d: Option[CountryDetail]): Unit = {
-    printf(
-      "%-5s %-10s %-10s %-10s %-10s\n",
-      "",
-      c.name,
-      c.capital,
-      c.region,
-      d.map(_.currency))
-  }
+
 }

--- a/src/main/scala/tagless/FinallyCountryApplication.scala
+++ b/src/main/scala/tagless/FinallyCountryApplication.scala
@@ -34,7 +34,7 @@ object FinallyCountryApplication extends App with ApplicationWrapper {
     */
   object FutureBasedApplication {
     val countriesService =
-      new CountriesService(CountriesApiInterpreter, LoggerInterpreter)
+      new CountriesService(CountriesApiInterpreter, FutureLoggerInterpreter)
 
     val result: Future[List[(Country, Option[CountryDetail])]] =
       countriesService.getCountriesWithDetails

--- a/src/main/scala/tagless/FinallyCountryApplication.scala
+++ b/src/main/scala/tagless/FinallyCountryApplication.scala
@@ -26,7 +26,6 @@ object FinallyCountryApplication extends App with ApplicationWrapper {
 
     val result: (List[String], List[(Country, Option[CountryDetail])]) =
       countriesService.getCountriesWithDetails.runEmpty.value
-
   }
 
   /**

--- a/src/main/scala/tagless/FinallyCountryApplication.scala
+++ b/src/main/scala/tagless/FinallyCountryApplication.scala
@@ -1,11 +1,11 @@
 package tagless
 
-import model.{Country, CountryDetail}
 import cats.implicits._
+import model.{Country, CountryDetail}
 import utils.ApplicationWrapper
 
-import scala.concurrent.{Await, Future}
 import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
 
 object FinallyCountryApplication extends App with ApplicationWrapper {
 
@@ -20,8 +20,9 @@ object FinallyCountryApplication extends App with ApplicationWrapper {
     */
   object StateBasedApplication {
     val countriesService =
-      new CountriesService(CountriesStateInterpreter,
-                           LoggerStateInterpreter)
+      new CountriesService(
+        CountriesStateInterpreter,
+        LoggerStateInterpreter)
 
     val result: (List[String], List[(Country, Option[CountryDetail])]) =
       countriesService.getCountriesWithDetails.runEmpty.value
@@ -43,26 +44,16 @@ object FinallyCountryApplication extends App with ApplicationWrapper {
 
   application("Tagless Final") {
     appVariantExecution("State Monad") {
-      StateBasedApplication.result._2.foreach { lc =>
-        printf("%-5s %-10s %-10s %-10s %-10s\n",
-               "",
-               lc._1.name,
-               lc._1.capital,
-               lc._1.region,
-               lc._2.map(_.currency))
+      StateBasedApplication.result._2.foreach {
+        case (c, d) => printResult(c, d)
       }
     }
 
     appVariantExecution("Future") {
       val futureResult = Await
         .result(FutureBasedApplication.result, atMost = Duration.Inf)
-      futureResult.foreach { lc =>
-        printf("%-5s %-10s %-10s %-10s %-10s\n",
-               "",
-               lc._1.name,
-               lc._1.capital,
-               lc._1.region,
-               lc._2.map(_.currency))
+      futureResult.foreach {
+        case (c, d) => printResult(c, d)
       }
     }
 
@@ -70,4 +61,13 @@ object FinallyCountryApplication extends App with ApplicationWrapper {
       StateBasedApplication.result._1.foreach(l => println(s"""\t$l""")))
   }
 
+  private def printResult(c: Country, d: Option[CountryDetail]): Unit = {
+    printf(
+      "%-5s %-10s %-10s %-10s %-10s\n",
+      "",
+      c.name,
+      c.capital,
+      c.region,
+      d.map(_.currency))
+  }
 }

--- a/src/main/scala/tagless/LoggerAlgInterpreter.scala
+++ b/src/main/scala/tagless/LoggerAlgInterpreter.scala
@@ -4,14 +4,14 @@ import model.LogLevel
 
 import scala.concurrent.Future
 
-object LoggerInterpreter extends Logger[Future] {
+object FutureLoggerInterpreter extends LoggerApiAlg[Future] {
   override def logMsg(level: LogLevel, msg: String): Future[Unit] = {
     println(s"$level => $msg")
     Future.successful(())
   }
 }
 
-object StateLoggerInterpreter extends Logger[ListState] {
+object StateLoggerInterpreter extends LoggerApiAlg[ListState] {
   override def logMsg(level: LogLevel, msg: String): ListState[Unit] = {
     addToState(s"$level => $msg", ())
   }

--- a/src/main/scala/tagless/LoggerInterpreter.scala
+++ b/src/main/scala/tagless/LoggerInterpreter.scala
@@ -1,15 +1,13 @@
 package tagless
 
-import cats.data.OptionT
-import cats.instances.future._
 import model.LogLevel
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
-object LoggerInterpreter extends Logger[FutureOfOption] {
-  override def logMsg(level: LogLevel, msg: String): FutureOfOption[Unit] = {
+object LoggerInterpreter extends Logger[Future] {
+  override def logMsg(level: LogLevel, msg: String): Future[Unit] = {
     println(s"$level => $msg")
-    OptionT.pure(())
+    Future.successful(())
   }
 }
 

--- a/src/main/scala/tagless/LoggerInterpreters.scala
+++ b/src/main/scala/tagless/LoggerInterpreters.scala
@@ -4,14 +4,14 @@ import model.LogLevel
 
 import scala.concurrent.Future
 
-object FutureLoggerInterpreter extends LoggerApiAlg[Future] {
+object LoggerFutureInterpreter extends LoggerApi[Future] {
   override def logMsg(level: LogLevel, msg: String): Future[Unit] = {
     println(s"$level => $msg")
     Future.successful(())
   }
 }
 
-object StateLoggerInterpreter extends LoggerApiAlg[ListState] {
+object LoggerStateInterpreter extends LoggerApi[ListState] {
   override def logMsg(level: LogLevel, msg: String): ListState[Unit] = {
     addToState(s"$level => $msg", ())
   }

--- a/src/main/scala/tagless/package.scala
+++ b/src/main/scala/tagless/package.scala
@@ -1,8 +1,6 @@
-import cats.data.{OptionT, State}
-import scala.concurrent.Future
+import cats.data.State
 
 package object tagless {
-  type FutureOfOption[A] = OptionT[Future, A]
   type ListState[A]      = State[List[String], A]
 
   def addToState[A](s: String, elem: A): ListState[A] =

--- a/src/test/scala/free/CountriesServiceSpec.scala
+++ b/src/test/scala/free/CountriesServiceSpec.scala
@@ -26,7 +26,7 @@ class CountriesServiceSpec extends FlatSpec with Matchers {
     val interpreters = CountryOpsTestInterpreters(countries, countryDetail) or
       LoggerOpsInterpreters.loggerListStateInterpreter
 
-    val listState: ListState[List[(Country, CountryDetail)]] =
+    val listState: ListState[List[(Country, Option[CountryDetail])]] =
       fetchCountries
       .foldMap(interpreters)
 

--- a/src/test/scala/free/CountriesServiceSpec.scala
+++ b/src/test/scala/free/CountriesServiceSpec.scala
@@ -1,23 +1,13 @@
 package free
 
-import model.{Country, CountryDetail}
-import org.scalatest.{FlatSpec, Matchers}
 import cats.implicits._
 import free.CountriesService.fetchCountries
+import model.{CountriesData, Country, CountryDetail}
+import org.scalatest.{FlatSpec, Matchers}
 
 class CountriesServiceSpec extends FlatSpec with Matchers {
 
-  val countries =
-    List(
-      Country("England" , "London", "Europe", "flag"),
-      Country("Spain"   , "Madrid", "Europe", "flag")
-    )
-
-  val countryDetail =
-    List(
-      CountryDetail("England" , "GBP"),
-      CountryDetail("Spain"   , "Euro")
-    )
+  import CountriesData._
 
   behavior of "Free Monad CountriesService"
 

--- a/src/test/scala/free/CountriesServiceSpec.scala
+++ b/src/test/scala/free/CountriesServiceSpec.scala
@@ -13,7 +13,7 @@ class CountriesServiceSpec extends FlatSpec with Matchers {
 
   it should "get all countries and details for each country in a combined result" in {
 
-    val interpreters = CountryOpsTestInterpreters(countries, countryDetail) or
+    val interpreters = CountryOpsTestInterpreters(countryData, countryDetailData) or
       LoggerOpsInterpreters.loggerListStateInterpreter
 
     val listState: ListState[List[(Country, Option[CountryDetail])]] =

--- a/src/test/scala/free/CountriesServiceSpec.scala
+++ b/src/test/scala/free/CountriesServiceSpec.scala
@@ -2,12 +2,12 @@ package free
 
 import cats.implicits._
 import free.CountriesService.fetchCountries
-import model.{CountriesData, Country, CountryDetail}
+import model.{CountryData, Country, CountryDetail}
 import org.scalatest.{FlatSpec, Matchers}
 
 class CountriesServiceSpec extends FlatSpec with Matchers {
 
-  import CountriesData._
+  import CountryData._
 
   behavior of "Free Monad CountriesService"
 

--- a/src/test/scala/free/CountriesServiceSpec.scala
+++ b/src/test/scala/free/CountriesServiceSpec.scala
@@ -20,16 +20,14 @@ class CountriesServiceSpec extends FlatSpec with Matchers {
       fetchCountries
       .foldMap(interpreters)
 
-    val result = listState.runEmpty.value
+    val (logs, results) = listState.runEmpty.value
 
     println("Consolidated log from running the interpreter:")
-    result._1.foreach(l => println(s"""\t\t$l"""))
+    logs.foreach(l => println(s"""\t\t$l"""))
 
-    result._2 shouldBe List(
-      (Country("England", "London", "Europe", "flag"),
-        CountryDetail("England", "GBP")),
-      (Country("Spain", "Madrid", "Europe", "flag"),
-        CountryDetail("Spain", "Euro"))
+    results shouldBe List(
+      (Country("England", "London", "Europe", "flag"), Some(CountryDetail("England", "GBP"))),
+      (Country("Spain", "Madrid", "Europe", "flag"), Some(CountryDetail("Spain", "Euro")))
     )
   }
 }

--- a/src/test/scala/free/CountryOpsTestInterpreters.scala
+++ b/src/test/scala/free/CountryOpsTestInterpreters.scala
@@ -6,15 +6,14 @@ object CountryOpsTestInterpreters {
   def apply(countries: List[Country], details: List[CountryDetail]): (CountriesAlg ~> ListState) =
     new (CountriesAlg ~> ListState) {
       override def apply[A](op: CountriesAlg[A]): ListState[A] = op match {
-        case GetCountyDetail(country) => {
+        case CountyDetail(country) =>
           val result = details.find(_.name.equalsIgnoreCase(country.name))
-          addToState(s"""\t${result.toString}""", result.get.asInstanceOf[A])
-        }
+          addToState(s"""\t${result.toString}""", result)
 
-        case GetCountries() =>
+        case Countries() =>
           addManyToState(
             countries.map(c => s"""\tCountry: ${c.name}, ${c.region}"""),
-            countries.asInstanceOf[A])
+            countries)
       }
     }
 }

--- a/src/test/scala/free/CountryOpsTestInterpreters.scala
+++ b/src/test/scala/free/CountryOpsTestInterpreters.scala
@@ -3,9 +3,9 @@ import cats.~>
 import model.{Country, CountryDetail}
 
 object CountryOpsTestInterpreters {
-  def apply(countries: List[Country], details: List[CountryDetail]): (CountriesApiAlg ~> ListState) =
-    new (CountriesApiAlg ~> ListState) {
-      override def apply[A](op: CountriesApiAlg[A]): ListState[A] = op match {
+  def apply(countries: List[Country], details: List[CountryDetail]): (CountriesAlg ~> ListState) =
+    new (CountriesAlg ~> ListState) {
+      override def apply[A](op: CountriesAlg[A]): ListState[A] = op match {
         case GetCountyDetail(country) => {
           val result = details.find(_.name.equalsIgnoreCase(country.name))
           addToState(s"""\t${result.toString}""", result.get.asInstanceOf[A])

--- a/src/test/scala/tagless/CountriesApiTestInterpreter.scala
+++ b/src/test/scala/tagless/CountriesApiTestInterpreter.scala
@@ -3,7 +3,7 @@ package tagless
 import model.{Country, CountryDetail}
 
 class CountriesApiTestInterpreter(countries: List[Country], details: List[CountryDetail]) extends
-  CountriesApiAlg[ListState]{
+  CountriesApi[ListState]{
 
   override def getCountries: ListState[List[Country]] =
     addManyToState(countries.map(c => s"""\tCountry: ${c.name}, ${c.region}"""), countries)

--- a/src/test/scala/tagless/CountriesApiTestInterpreter.scala
+++ b/src/test/scala/tagless/CountriesApiTestInterpreter.scala
@@ -2,14 +2,14 @@ package tagless
 
 import model.{Country, CountryDetail}
 
-class CountriesApiTestInterpreter(countries: List[Country], details: List[CountryDetail]) extends
+class CountriesApiTestInterpreter(countryData: List[Country], detailData: List[CountryDetail]) extends
   CountriesApi[ListState]{
 
-  override def getCountries: ListState[List[Country]] =
-    addManyToState(countries.map(c => s"""\tCountry: ${c.name}, ${c.region}"""), countries)
+  override def countries: ListState[List[Country]] =
+    addManyToState(countryData.map(c => s"""\tCountry: ${c.name}, ${c.region}"""), countryData)
 
-  override def getCountryDetail(country: Country): ListState[Option[CountryDetail]] = {
-    val result = details.find(_.name.equalsIgnoreCase(country.name))
+  override def countryDetail(country: Country): ListState[Option[CountryDetail]] = {
+    val result = detailData.find(_.name.equalsIgnoreCase(country.name))
 
     addToState(s"""\t${result.toString}""", result)
   }

--- a/src/test/scala/tagless/CountriesApiTestInterpreter.scala
+++ b/src/test/scala/tagless/CountriesApiTestInterpreter.scala
@@ -8,7 +8,7 @@ class CountriesApiTestInterpreter(countries: List[Country], details: List[Countr
   override def getCountries: ListState[List[Country]] =
     addManyToState(countries.map(c => s"""\tCountry: ${c.name}, ${c.region}"""), countries)
 
-  override def getCountyDetail(country: Country): ListState[Option[CountryDetail]] = {
+  override def getCountryDetail(country: Country): ListState[Option[CountryDetail]] = {
     val result = details.find(_.name.equalsIgnoreCase(country.name))
 
     addToState(s"""\t${result.toString}""", result)

--- a/src/test/scala/tagless/CountriesApiTestInterpreter.scala
+++ b/src/test/scala/tagless/CountriesApiTestInterpreter.scala
@@ -8,8 +8,8 @@ class CountriesApiTestInterpreter(countries: List[Country], details: List[Countr
   override def getCountries: ListState[List[Country]] =
     addManyToState(countries.map(c => s"""\tCountry: ${c.name}, ${c.region}"""), countries)
 
-  override def getCountyDetail(country: Country): ListState[CountryDetail] = {
-    val result = details.find(_.name.equalsIgnoreCase(country.name)).get
+  override def getCountyDetail(country: Country): ListState[Option[CountryDetail]] = {
+    val result = details.find(_.name.equalsIgnoreCase(country.name))
 
     addToState(s"""\t${result.toString}""", result)
   }

--- a/src/test/scala/tagless/CountriesServiceSpec.scala
+++ b/src/test/scala/tagless/CountriesServiceSpec.scala
@@ -25,16 +25,14 @@ class CountriesServiceSpec extends FlatSpec with Matchers {
     val interpreter = new CountriesApiTestInterpreter(countries, countryDetail)
     val api = new CountriesService(interpreter, LoggerTestInterpreter)
 
-    val result = api.getCountriesWithDetails.runEmpty.value
+    val (logs, results) = api.getCountriesWithDetails.runEmpty.value
 
     println("Consolidated log from running the interpreter:")
-    result._1.foreach(l => println(s"""\t\t$l"""))
+    logs.foreach(l => println(s"""\t\t$l"""))
 
-    result._2 shouldBe List(
-      (Country("England", "London", "Europe", "flag"),
-       Some(CountryDetail("England", "GBP"))),
-      (Country("Spain", "Madrid", "Europe", "flag"),
-       Some(CountryDetail("Spain", "Euro")))
+    results shouldBe List(
+      (Country("England", "London", "Europe", "flag"), Some(CountryDetail("England", "GBP"))),
+      (Country("Spain", "Madrid", "Europe", "flag"), Some(CountryDetail("Spain", "Euro")))
     )
   }
 }

--- a/src/test/scala/tagless/CountriesServiceSpec.scala
+++ b/src/test/scala/tagless/CountriesServiceSpec.scala
@@ -32,9 +32,9 @@ class CountriesServiceSpec extends FlatSpec with Matchers {
 
     result._2 shouldBe List(
       (Country("England", "London", "Europe", "flag"),
-       CountryDetail("England", "GBP")),
+       Some(CountryDetail("England", "GBP"))),
       (Country("Spain", "Madrid", "Europe", "flag"),
-       CountryDetail("Spain", "Euro"))
+       Some(CountryDetail("Spain", "Euro")))
     )
   }
 }

--- a/src/test/scala/tagless/LoggerTestInterpreter.scala
+++ b/src/test/scala/tagless/LoggerTestInterpreter.scala
@@ -1,7 +1,7 @@
 package tagless
 import model.LogLevel
 
-object LoggerTestInterpreter extends LoggerApiAlg[ListState] {
+object LoggerTestInterpreter extends LoggerApi[ListState] {
   override def logMsg(level: LogLevel, msg: String): ListState[Unit] = {
     addToState(s"$level => $msg", ())
   }

--- a/src/test/scala/tagless/LoggerTestInterpreter.scala
+++ b/src/test/scala/tagless/LoggerTestInterpreter.scala
@@ -1,7 +1,7 @@
 package tagless
 import model.LogLevel
 
-object LoggerTestInterpreter extends Logger[ListState] {
+object LoggerTestInterpreter extends LoggerApiAlg[ListState] {
   override def logMsg(level: LogLevel, msg: String): ListState[Unit] = {
     addToState(s"$level => $msg", ())
   }


### PR DESCRIPTION
The Free Ops injectors are now instances of the Tagless api traits and there is a generic Free natural transformation interpreter that can be implemented by delegating off to a tagless implementation.